### PR TITLE
Edge case: Handle media that has no file extension

### DIFF
--- a/extension/app/js/cards.js
+++ b/extension/app/js/cards.js
@@ -36,12 +36,14 @@ function processIntervals(interv){
 	});
 }
 
-function replaceAudioTags(html){
-	return html.replace(/\[sound:([^\]]*)\]/, (match, filename)=>{
-		let mediaType="audio"
-		if(MIME['.'+filename.split('.').pop()].split('/')[0]=="video")
-			mediaType="video"
-		return '<'+mediaType+' controls src="'+filename+'"></'+mediaType+'>'
+function replaceAudioTags(html) {
+	return html.replace(/\[sound:([^\]]*)\]/, (match, filename) => {
+		let mediaType = "audio";
+		let extension = '.' + filename.split('.').pop();
+		let mimeType = (MIME[extension] || "").split('/')[0];
+		if (mimeType == "video")
+			mediaType = "video";
+		return '<' + mediaType + ' controls src="' + filename + '"></' + mediaType + '>';
 	});
 }
 


### PR DESCRIPTION
# Problem

 * Desktop Anki does not require a file extension for audio media
 * AnkiTab _does_ require a file extension (and raises a runtime exception when the media does not have it)

# Solution

 * Allow media that does not have a file extension, mirroring behaviour in desktop version of Anki.
