### PR TITLE
Improved Dark Theme (cards now white-on-black text) and max-image widths

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@
 - [**Chrome** extension][link-cws] [<img valign="middle" src="https://img.shields.io/chrome-web-store/v/ihoaepdiibjbifnhcjoaddgcnfgjmjdk.svg?label=%20">][link-cws]
 - [**Firefox** add-on](https://github.com/corollari/ankiTab/issues/3)
 
+### Recent releases
+- v0.5.4 (Nov 11, 2021) - improved dark mode (cards are made white-on-black text), image widths now limited to <100% of card width. 
+
 ## Build
 ##### Setup:
 ```bash

--- a/extension/app/css/main.css
+++ b/extension/app/css/main.css
@@ -5,7 +5,7 @@
         position:fixed;
         bottom:0;
         width:100%;
-        background-color:#000;
+        background-color:rgba(0,0,0,0.1);
 }
 #answerButtons{
         margin:auto;

--- a/extension/app/css/main.css
+++ b/extension/app/css/main.css
@@ -1,5 +1,6 @@
 #flashcardParent{
         border:none;
+        background-color: transparent;
 }
 #answerButtonsParent{
         position:fixed;
@@ -43,6 +44,21 @@
     border: none;
     margin: 0; padding: 0;
 }
+
+/* Dark-theme on Sandbox */
+#flashcardSandboxHtml body { background-color: transparent; }
+
+#flashcardSandboxHtml .dark-theme .card {
+    background-color: #121212;
+    color: #fff;
+}
+
+/* For those who use retina images that are otherwise too big */
+#flashcardSandboxHtml img {
+    max-width: 100%;
+}
+
+
 .pointerHover {
 	cursor: pointer;
 	user-select: none;

--- a/extension/app/js/main.js
+++ b/extension/app/js/main.js
@@ -11,11 +11,17 @@ const btn = document.querySelector("#darkmodeEnabled");
 const currentTheme = localStorage.getItem("theme");
 if (currentTheme == "dark") {
   document.body.classList.add("dark-theme");
+  document.querySelector("#flashcardSandbox").contentWindow.postMessage({
+		'command': 'toggle-dark-theme'
+	}, '*');
 }
 
 btn.addEventListener("click", function () {
   document.body.classList.toggle("dark-theme");
-
+  document.querySelector("#flashcardSandbox").contentWindow.postMessage({
+		'command': 'toggle-dark-theme'
+	}, '*');
+  
   let theme = "light";
   if (document.body.classList.contains("dark-theme")) {
     theme = "dark";

--- a/extension/app/js/sandbox.js
+++ b/extension/app/js/sandbox.js
@@ -25,6 +25,10 @@ window.addEventListener('message', async function(event) {
         document.querySelectorAll(`[src="${decodeURI(event.data.oldSrc)}"]`).forEach(async (elem)=>{
           elem.src = event.data.newSrc
         });
+        break;
+    case 'toggle-dark-theme': 
+        document.body.classList.toggle("dark-theme");
+        break;
     }
 })
 

--- a/extension/app/sandbox.html
+++ b/extension/app/sandbox.html
@@ -1,6 +1,6 @@
 <!-- AnkiTab -->
 <!doctype html>
-<html>
+<html id="flashcardSandboxHtml">
 	<head>
 		<link rel="stylesheet" href="../libs/bootstrap.css">
 		<link rel="stylesheet" href="./css/main.css">

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "AnkiTab",
-	"version": "0.5.3",
+	"version": "0.5.4",
 	"description": "Replace new tab page with Anki flashcards",
 	"manifest_version": 2,
 	"incognito": "split",

--- a/manifests/chromeManifest.json
+++ b/manifests/chromeManifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "AnkiTab",
-	"version": "0.5.3",
+	"version": "0.5.4",
 	"description": "Replace new tab page with Anki flashcards",
 	"manifest_version": 2,
 	"incognito": "split",

--- a/manifests/firefoxManifest.json
+++ b/manifests/firefoxManifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "AnkiTab",
-	"version": "0.5.3",
+	"version": "0.5.4",
 	"description": "Replace new tab page with Anki flashcards",
 	"manifest_version": 2,
 	"background":{


### PR DESCRIPTION
This PR is in direct response to
-  https://github.com/corollari/ankiTab/issues/11 (max image-width for those of us who have retina-sized screenshots on our cards that are otherwise too big and require a lot of side-to-side scrolling)
- https://github.com/corollari/ankiTab/issues/31 
- bumped version to v0.5.4

See attached .zips for the .bash generated extensions (unsigned, not yet on webstore)
[firefox.zip](https://github.com/corollari/ankiTab/files/7524229/firefox.zip)
[chrome.zip](https://github.com/corollari/ankiTab/files/7524226/chrome.zip)
